### PR TITLE
remove underlining in button links

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -52,11 +52,13 @@ a:hover {
   border-radius: 5px;
   padding: var(--btn-padding);
   border: none;
+  text-decoration: none;
 }
 
 .btn:hover {
   color: var(--link);
   background-color: var(--background);
+  text-decoration: revert;
 }
 
 #toggleTheme {


### PR DESCRIPTION
I think the buttons look better without underlining, and that it is clear they are buttons. It's less clear when they are hovered, so putting underline back in then.