### PR TITLE
Make SC/GC member lists more readable without logos

### DIFF
--- a/pages/team.html
+++ b/pages/team.html
@@ -198,28 +198,11 @@ title: "Open Web Docs - Team"
         of organizations that have made substantial financial contributions to
         OWD, and include one representative from staff.
       </p>
-      <ul class="grid-container">
-        <li>
-          <h4 class="center">Coil</h4>
-          <img src="/img/coil.png" alt="Coil logo" class="sponsor-icon" />
-        </li>
-        <li>
-          <h4 class="center">Google</h4>
-          <img src="/img/google.png" alt="Google logo" class="sponsor-icon" />
-        </li>
-        <li>
-          <h4 class="center">Meta</h4>
-          <img
-            src="/img/meta-dark.svg"
-            data-lightsrc="/img/meta-light.svg"
-            alt="Meta logo"
-            class="meta sponsor-icon"
-          />
-        </li>
-        <li>
-          <h4 class="center">Microsoft Edge</h4>
-          <img src="/img/edge.png" alt="Microsoft logo" class="sponsor-icon" />
-        </li>
+      <ul>
+        <li>Coil</li>
+        <li>Google</li>
+        <li>Meta</li>
+        <li>Microsoft Edge</li>
       </ul>
       <p>
         In addition, the following individuals are advisory members on the OWD
@@ -245,72 +228,18 @@ title: "Open Web Docs - Team"
         Our Steering Committee includes representatives from the following
         organizations:
       </p>
-      <ul class="grid-container">
-        <li>
-          <h4 class="center">Apple</h4>
-          <img src="/img/apple.png" alt="Apple logo" class="sponsor-icon" />
-        </li>
-        <li>
-          <h4 class="center">Coil</h4>
-          <img src="/img/coil.png" alt="Coil logo" class="sponsor-icon" />
-        </li>
-        <li>
-          <h4 class="center">Google</h4>
-          <img src="/img/google.png" alt="Google logo" class="sponsor-icon" />
-        </li>
-        <li>
-          <h4 class="center">Meta</h4>
-          <img
-            src="/img/meta-dark.svg"
-            data-lightsrc="/img/meta-light.svg"
-            alt="Meta logo"
-            class="meta sponsor-icon"
-          />
-        </li>
-        <li>
-          <h4 class="center">Microsoft Edge</h4>
-          <img src="/img/edge.png" alt="Microsoft logo" class="sponsor-icon" />
-        </li>
-        <li>
-          <h4 class="center">Canva</h4>
-          <img src="/img/canva.png" alt="Canva logo" class="sponsor-icon" />
-        </li>
-        <li>
-          <h4 class="center">Igalia</h4>
-          <img src="/img/igalia.png" alt="Igalia logo" class="sponsor-icon" />
-        </li>
-        <li>
-          <h4 class="center">Jetbrains</h4>
-          <img
-            src="/img/jetbrains.png"
-            alt="JetBrains logo"
-            class="sponsor-icon"
-          />
-        </li>
-        <li>
-          <h4 class="center">Mozilla</h4>
-          <img
-            src="/img/mozilla-light.png"
-            data-lightsrc="/img/mozilla-dark.png"
-            alt="Mozilla logo"
-            id="moz"
-            class="sponsor-icon"
-          />
-        </li>
-        <li>
-          <h4 class="center">Samsung Internet</h4>
-          <img
-            src="/img/samsung-light.png"
-            data-lightsrc="/img/samsung-dark.png"
-            alt="Samsung logo"
-            id="sam"
-            class="sponsor-icon"
-          />
-        </li>
-        <li>
-          <h4 class="center">W3C</h4>
-          <img src="/img/w3c.svg" alt="W3C logo" class="sponsor-icon" />
-        </li>
+      <ul>
+        <li>Apple</li>
+        <li>Coil</li>
+        <li>Google</li>
+        <li>Meta</li>
+        <li>Microsoft Edge</li>
+        <li>Canva</li>
+        <li>Igalia</li>
+        <li>JetBrains</li>
+        <li>Mozilla</li>
+        <li>Samsung Internet</li>
+        <li>W3C</li>
       </ul>
     </section>
   </div>


### PR DESCRIPTION
I think we don't need to put logos everywhere. I think it is a lot more readable without them. 
Also, prominent logo placement is for paying sponsors only.