### PR TITLE
Embiggen Meta logo

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -247,6 +247,11 @@ nav,
   padding-left: var(--nested-spacing);
 }
 
+img.meta {
+  min-width: 170px;
+  margin-left: -30px;
+}
+
 .home-bg {
   background-image: url("../img/svg-wave-bg.svg");
   background-size: cover;


### PR DESCRIPTION
Fixes https://github.com/openwebdocs/owd-website/issues/28.

This is pretty hacky, and I'd welcome a better option, but it works (and I think this issue is a blocker).

<img width="834" alt="Screen Shot 2022-09-09 at 11 41 08 AM" src="https://user-images.githubusercontent.com/432915/189421433-4bd1a762-0b22-4aed-b79b-a474b16206a3.png">

It would be nicer all round if we could just use the symbol without the word, but idk if that is acceptable.