### PR TITLE
Remove max width for mobile

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -334,10 +334,6 @@ footer {
     max-width: 25rem;
   }
 
-  .post-item {
-    max-width: var(--sm-paragraph);
-  }
-
   nav,
   #home-main,
   .sec-container,


### PR DESCRIPTION
I think a full-width paragraph looks fine on mobile, and would prefer to reduce the white space on wider mobile devices. Not sure if people agree.

after and before screen shots: <img width="632" alt="Screen Shot 2022-09-12 at 12 23 42 PM" src="https://user-images.githubusercontent.com/69888/189738488-0494d202-246f-440c-b584-062333f3de1e.png">
<img width="625" alt="Screen Shot 2022-09-12 at 12 24 03 PM" src="https://user-images.githubusercontent.com/69888/189738499-7d4c37e1-e866-4b20-a893-6471dec9171c.png">