### PR TITLE
Fix Mastodon links

### DIFF
--- a/pages/404.html
+++ b/pages/404.html
@@ -72,7 +72,7 @@
             /></a>
           </li>
           <li>
-            <a href="https://front-end.social/OpenWebDocs"
+            <a href="https://front-end.social/@OpenWebDocs"
               ><img
                 src="/img/mastodon.png"
                 alt="Mastodon logo icon"

--- a/pages/_includes/layouts/default.njk
+++ b/pages/_includes/layouts/default.njk
@@ -101,7 +101,7 @@
               /></a>
             </li>
             <li>
-              <a href="https://front-end.social/OpenWebDocs"
+              <a href="https://front-end.social/@OpenWebDocs"
                 ><img
                   src="/img/mastodon.png"
                   alt="Mastodon logo icon"

--- a/pages/get-involved.html
+++ b/pages/get-involved.html
@@ -65,7 +65,7 @@ title: "Open Web Docs - Get Involved"
       >Writing Day at the Write the Docs conference</a
     >. We come with a list of projects for you to work on, or you can bring your
     own, and we will help you get started.
-    <a href="https://front-end.social/OpenWebDocs">Follow us on Mastodon</a> to
+    <a href="https://front-end.social/@OpenWebDocs">Follow us on Mastodon</a> to
     learn about events we'll be at!
   </p>
 

--- a/pages/team.html
+++ b/pages/team.html
@@ -37,7 +37,7 @@ title: "Open Web Docs - Team"
             /></a>
           </li>
           <li>
-            <a href="http://front-end.social/estelle"
+            <a href="https://front-end.social/@estelle"
               ><img
                 src="/img/mastodon.png"
                 alt="Estelle's Mastodon"
@@ -155,7 +155,7 @@ title: "Open Web Docs - Team"
             /></a>
           </li>
           <li>
-            <a href="https://mastodon.social/queengooborg"
+            <a href="https://mastodon.social/@queengooborg"
               ><img src="/img/mastodon.png" alt="Vinyl's Mastodon" class="icon"
             /></a>
           </li>


### PR DESCRIPTION
This PR is a follow-up to #69 that fixes the links to Mastodon, adding a missing `@` to all links.
