### PR TITLE
Remove JetBrains

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -50,8 +50,5 @@ bodyClass: home-bg
     <li>
       <img src="/img/igalia.png" alt="Igalia logo" class="sponsor-icon" />
     </li>
-    <li>
-      <img src="/img/jetbrains.png" alt="JetBrains logo" class="sponsor-icon" />
-    </li>
   </ul>
 </section>

--- a/pages/sponsors.html
+++ b/pages/sponsors.html
@@ -43,11 +43,6 @@ title: "Open Web Docs - Sponsors"
     <span class="name">Canva</span>
   </div>
 
-  <div class="sponsor">
-    <img class="logo" src="/img/jetbrains.png" alt="JetBrains logo" />
-    <span class="name">JetBrains</span>
-  </div>
-
   <h2>Individual Sponsors</h2>
 
   <p>

--- a/pages/team.html
+++ b/pages/team.html
@@ -252,7 +252,6 @@ title: "Open Web Docs - Team"
         <li>Microsoft Edge</li>
         <li>Canva</li>
         <li>Igalia</li>
-        <li>JetBrains</li>
         <li>Mozilla</li>
         <li>Samsung Internet</li>
         <li>W3C</li>


### PR DESCRIPTION
Removes JetBrains from current sponsors list. Thanks for sponsoring us in 2021.