### PR TITLE
Separate sponsors from media

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -270,6 +270,10 @@ nav,
   padding-top: 1em;
 }
 
+[data-theme="light"] .home-bg footer {
+    border-top-color: #0002;
+}
+
 #logo {
   width: 30vw;
 }


### PR DESCRIPTION
On the home page of our website, in light mode, the separation line between the sponsors and the social media icons is the same color as the background, making it look like github, mastodon, and open collective give us $. This changes the color of that border, only on the home page, only in light mode.