### PR TITLE
Minor tweaks to sponsors footer

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -230,8 +230,7 @@ nav,
 }
 
 .footer-sponsors-list .nav-list {
-  margin-bottom: 0;
-  padding-bottom: var(--nested-spacing);
+  text-align: center;
 }
 
 .sec-container {
@@ -310,6 +309,7 @@ footer {
 
 .sponsors-link {
   color: var(--foreground);
+  text-decoration: none;
 }
 .sponsors-link:hover {
   color: var(--link);

--- a/pages/index.html
+++ b/pages/index.html
@@ -35,20 +35,28 @@ bodyClass: home-bg
 
 <section class="footer-sponsors-list center">
   <h3 class="center-text">
-    <a href="/sponsors" class="sponsors-link"> Sponsors </a>
+    <a href="/sponsors" class="sponsors-link">Sponsors</a>
   </h3>
   <ul class="flex-container center nav-list">
     <li>
       <img src="/img/canva.png" alt="Canva logo" class="sponsor-icon" />
+      <br />
+      Canva
     </li>
     <li>
       <img src="/img/edge.png" alt="Microsoft Edge logo" class="sponsor-icon" />
+      <br />
+      Microsoft Edge
     </li>
     <li>
       <img src="/img/google.png" alt="Google logo" class="sponsor-icon" />
+      <br />
+      Google
     </li>
     <li>
       <img src="/img/igalia.png" alt="Igalia logo" class="sponsor-icon" />
+      <br />
+      Igalia
     </li>
   </ul>
 </section>


### PR DESCRIPTION
Add sponsor names and have some space to the actual footer (so that GitHub, Mastodon, OC logos appear as just links, they are not our sponsors)