### PR TITLE
Remove Google from Platinum Sponsors list

### DIFF
--- a/pages/sponsors.html
+++ b/pages/sponsors.html
@@ -28,10 +28,6 @@ title: "Open Web Docs - Sponsors"
 
   <h2>Platinum Sponsors</h2>
 
-  <div class="sponsor">
-    <img class="logo" src="/img/google.png" alt="Google logo" />
-    <span class="name">Google Open Source</span>
-  </div>
 
   <div class="sponsor">
     <a href="https://developer.microsoft.com/microsoft-edge">


### PR DESCRIPTION
Removed Google Open Source from Platinum Sponsors section.